### PR TITLE
Convert Annotations Update

### DIFF
--- a/convert_annotations.py
+++ b/convert_annotations.py
@@ -60,10 +60,13 @@ for DIR in DIRS:
                                 for class_type in classes:
                                     line = line.replace(class_type, str(classes.get(class_type)))
                                 labels = line.split()
-                                coords = np.asarray([float(labels[1]), float(labels[2]), float(labels[3]), float(labels[4])])
+                                coords = np.asarray([float(labels[-4]), float(labels[-3]), float(labels[-2]), float(labels[-1])])
                                 coords = convert(filename_str, coords)
-                                labels[1], labels[2], labels[3], labels[4] = coords[0], coords[1], coords[2], coords[3]
-                                newline = str(labels[0]) + " " + str(labels[1]) + " " + str(labels[2]) + " " + str(labels[3]) + " " + str(labels[4])
+                                labels[-4], labels[-3], labels[-2], labels[-1] = coords[0], coords[1], coords[2], coords[3]
+                                newline = ""
+                                for l in labels:
+                                    newline+= l + " "
+                                newline = newline[:-1]
                                 line = line.replace(line, newline)
                                 annotations.append(line)
                             f.close()


### PR DESCRIPTION
A fix for the error when using a multispaced class name. For example "personal computer ". 